### PR TITLE
chore: quick-wins batch — #5 nosniff, #9/#10/#11 small refactors

### DIFF
--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -13,7 +13,9 @@ export const metadata: Metadata = {
 };
 
 export default function BrandsPage() {
-  const sortedBrands = [...brands].sort((a, b) => a.name.localeCompare(b.name));
+  const sortedBrands = brands.toSorted((a, b) =>
+    a.name.localeCompare(b.name),
+  );
 
   return (
     <div className="min-h-screen bg-white border-t border-primary-200">

--- a/components/ServicesGrid.tsx
+++ b/components/ServicesGrid.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import {
   faSnowflake,
   faFireFlameCurved,
@@ -13,7 +14,9 @@ import {
 
 import { services } from "@/lib/content";
 
-const iconMap: Record<string, any> = {
+type Service = (typeof services)[number];
+
+const iconMap: Record<string, IconDefinition> = {
   "air-conditioning": faSnowflake,
   heating: faFireFlameCurved,
   "heat-pumps": faArrowsRotate,
@@ -68,7 +71,7 @@ export default function ServicesGrid() {
   );
 }
 
-function ServiceTile({ service }: any) {
+function ServiceTile({ service }: { service: Service }) {
   const Icon = iconMap[service.slug];
   const [pressed, setPressed] = useState(false);
 

--- a/components/WhySturrocks.tsx
+++ b/components/WhySturrocks.tsx
@@ -5,8 +5,7 @@ type WhyItem = {
   text: string;
 };
 
-export default function WhySturrocks() {
-const items = [
+const WHY_ITEMS: readonly WhyItem[] = [
   {
     title: "State Licensed & Insured",
     text: "Fully compliant and professionally certified service.",
@@ -45,8 +44,9 @@ const items = [
   },
 ];
 
-  const topThree = items.slice(0, 3);
-  const topSix = items.slice(0, 6);
+export default function WhySturrocks() {
+  const topThree = WHY_ITEMS.slice(0, 3);
+  const topSix = WHY_ITEMS.slice(0, 6);
 
   return (
     <section className="bg-neutral-50 border-t border-white pt-10 pb-14 md:pt-12 md:pb-20">
@@ -78,7 +78,7 @@ const items = [
 
         {/* Large (9) */}
         <div className="hidden lg:grid lg:grid-cols-3 gap-6">
-          {items.map((item, index) => (
+          {WHY_ITEMS.map((item, index) => (
             <WhyCard key={index} item={item} />
           ))}
         </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,21 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_BUILD_ID: commitHash,
     NEXT_PUBLIC_BUILD_TIMESTAMP: buildTimestamp,
   },
+
+  async headers() {
+    return [
+      {
+        // Apply to every route.
+        source: "/:path*",
+        headers: [
+          // Prevent MIME-type sniffing — mitigates a class of XSS that
+          // relies on the browser ignoring Content-Type and executing a
+          // response as a different type (e.g. JS served as image).
+          { key: "X-Content-Type-Options", value: "nosniff" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Four small, related cleanups grouped into one PR.

| # | Issue | Change |
|---|-------|--------|
| #5 | Add \`X-Content-Type-Options: nosniff\` header | \`next.config.ts\` \`headers()\` emits on every route |
| #9 | Move \`WhySturrocks\` items to module-level constant | Hoisted to \`WHY_ITEMS\` readonly const |
| #10 | Replace \`[...brands].sort(...)\` with \`brands.toSorted(...)\` | One-liner swap |
| #11 | Replace \`any\` prop types in \`ServicesGrid\` | \`IconDefinition\` for the icon map; \`Service\` for the tile |

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean (production build, all 65 static pages generate)
- [x] Verified in DevTools → Network → Response Headers that \`x-content-type-options: nosniff\` is emitted on rendered pages
- [ ] After merge: verify deployed prod response includes the header (\`curl -I https://sturrockshvac.com\`)

Closes #5, #9, #10, #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)