### PR TITLE
perf: CLS fix + LCP improvement + static cache headers (closes #25)

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,8 @@
-"use client";
+// Server Component: lets the hero image ship in the initial SSR HTML
+// so the browser preloads it immediately (via Next.js Image's priority
+// attribute, which emits fetchpriority="high"). When this was a Client
+// Component the image wasn't in the server HTML, so the browser couldn't
+// establish it as the LCP candidate until after hydration.
 
 import Image from "next/image";
 import TrustBar from "./TrustBar";

--- a/components/ServicesGrid.tsx
+++ b/components/ServicesGrid.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+// Initialize FontAwesome before any icons render. Prevents the layout
+// shift caused by FA's default runtime CSS injection (see #25).
+import "@/lib/fontawesome";
+
 import Link from "next/link";
 import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/lib/fontawesome.ts
+++ b/lib/fontawesome.ts
@@ -1,0 +1,20 @@
+// FontAwesome initialization — import this module from any client
+// component that uses FontAwesomeIcon.
+//
+// FontAwesome by default injects its stylesheet dynamically at runtime.
+// That injection happens *after* the icons have already rendered at
+// default (often wrong) sizes, so when the CSS finally applies the icons
+// resize — pushing everything below them down and producing Cumulative
+// Layout Shift.
+//
+// The canonical fix, per FontAwesome's own docs:
+//   1. Import the stylesheet statically (Next.js bundles it into the
+//      page's CSS, loaded before any JS runs).
+//   2. Disable the runtime injection.
+//
+// Must be imported for side effects before any FontAwesomeIcon renders.
+
+import "@fortawesome/fontawesome-svg-core/styles.css";
+import { config } from "@fortawesome/fontawesome-svg-core";
+
+config.autoAddCss = false;

--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,42 @@ const nextConfig: NextConfig = {
           { key: "X-Content-Type-Options", value: "nosniff" },
         ],
       },
+      {
+        // Long cache for versioned static assets under /_next/static
+        // (content-hashed filenames, safe to cache immutably). Next.js
+        // usually sets this automatically but OpenNext + Cloudflare
+        // Workers serve from KV asset bindings where defaults may not
+        // apply — be explicit.
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        // Static image assets under /public/images and /public/hero.
+        // Not content-hashed, so use a shorter max-age but still cache
+        // for a day at the edge and in browsers.
+        source: "/:path(images|hero|brands)/:file*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=86400, stale-while-revalidate=604800",
+          },
+        ],
+      },
+      {
+        // Favicon / logo PNG. Small files, fine to cache aggressively.
+        source: "/:file(favicon.ico|icon.svg|icon.png|apple-icon.png|logo.png|og-image.jpg)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=604800, stale-while-revalidate=2592000",
+          },
+        ],
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary

Three related Web-Vitals fixes addressing Lighthouse + CFWA flags.

## The CLS win

Real-user CLS on the homepage is **0.27** (poor; target <0.1). Debug element was \`html.body.min-h-screen\` — the whole body shifting. Root cause confirmed: **FontAwesome's runtime CSS injection** — icons render at default (wrong) size on first paint, then resize when FA's dynamically-injected stylesheet finally applies, pushing everything below them down.

**Fix:** new \`lib/fontawesome.ts\` imports the FA stylesheet statically (bundled into Next.js page CSS, loaded before JS) and sets \`config.autoAddCss = false\`. \`ServicesGrid.tsx\` imports it for side effects before FontAwesomeIcon renders.

## The LCP improvement

\`Hero.tsx\` was marked \`"use client"\` unnecessarily, which meant the hero image wasn't in the SSR HTML — browser couldn't preload it as the LCP candidate or honor the \`priority\` hint until hydration. Removing the client directive lets it ship in the initial response. \`getCurrentSeason()\` is pure Date math and works fine server-side.

## Cache-Control headers

\`next.config.ts\` \`headers()\` extended with three explicit caching rules:

| Path | Cache-Control |
|------|---------------|
| \`/_next/static/*\` (content-hashed) | \`public, max-age=31536000, immutable\` |
| \`/images\|hero\|brands/*\` | \`public, max-age=86400, stale-while-revalidate=604800\` |
| favicons + logo + og-image | \`public, max-age=604800, stale-while-revalidate=2592000\` |

## Expected impact

- **CLS:** 0.27 → <0.1 (should hit "Good" in CFWA within a few hours of real traffic)
- **LCP:** already 93% good, possibly minor improvement from proper SSR preload
- **Transfer savings:** 44 KiB cache-lifetime savings Lighthouse flagged should largely clear

## Test plan

- [x] \`npm run lint\` + \`npx tsc --noEmit\` clean
- [x] \`npm run build\` production build clean
- [ ] After deploy: re-run Lighthouse on /, confirm CLS < 0.1
- [ ] Check CFWA dashboard over next 24–48h for real-user CLS improvement
- [ ] Verify \`curl -I https://sturrockshvac.com/images/logo.png\` returns the new Cache-Control header

Closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)