### PR TITLE
perf: strip 3 extra Cache-Control rules (1102 mitigation)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,51 +21,21 @@ const nextConfig: NextConfig = {
   },
 
   async headers() {
+    // NOTE: keep this list minimal. Each rule runs a path-to-regexp match
+    // on every response. PR #28 added 3 extra Cache-Control rules and
+    // Lighthouse started returning Cloudflare Error 1102 (Worker CPU
+    // budget, 10ms on Free tier). Reverted to just nosniff to stay under
+    // budget. If we need explicit cache-control on static assets again,
+    // set them at the Cloudflare zone level (Page Rules) or upgrade to
+    // Workers Paid.
     return [
       {
-        // Apply to every route.
         source: "/:path*",
         headers: [
           // Prevent MIME-type sniffing — mitigates a class of XSS that
           // relies on the browser ignoring Content-Type and executing a
           // response as a different type (e.g. JS served as image).
           { key: "X-Content-Type-Options", value: "nosniff" },
-        ],
-      },
-      {
-        // Long cache for versioned static assets under /_next/static
-        // (content-hashed filenames, safe to cache immutably). Next.js
-        // usually sets this automatically but OpenNext + Cloudflare
-        // Workers serve from KV asset bindings where defaults may not
-        // apply — be explicit.
-        source: "/_next/static/:path*",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
-          },
-        ],
-      },
-      {
-        // Static image assets under /public/images and /public/hero.
-        // Not content-hashed, so use a shorter max-age but still cache
-        // for a day at the edge and in browsers.
-        source: "/:path(images|hero|brands)/:file*",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=86400, stale-while-revalidate=604800",
-          },
-        ],
-      },
-      {
-        // Favicon / logo PNG. Small files, fine to cache aggressively.
-        source: "/:file(favicon.ico|icon.svg|icon.png|apple-icon.png|logo.png|og-image.jpg)",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=604800, stale-while-revalidate=2592000",
-          },
         ],
       },
     ];


### PR DESCRIPTION
## Problem

PR #28 added 3 Cache-Control rules to \`next.config.ts\` \`headers()\`. After that deploy, Lighthouse runs started returning CF Workers Error 1102 (CPU budget exceeded on Workers Free tier — 10ms per request).

Each \`headers()\` rule runs a path-to-regexp match on every response. Going from 1 rule (just nosniff) to 4 rules quadruples per-response header-matching CPU. Under Lighthouse's parallel audit load, that could be enough to push us over 10ms.

## Fix

Revert to just the \`nosniff\` rule. Cache lifetimes for static assets can be set at the Cloudflare zone level (Page Rules) — moves the work off the Worker entirely.

## Caveat

If 1102 persists after this, it's not the headers rules — it's a deeper issue with OpenNext+Workers on Free tier for our site size (60+ prerendered pages, likely large Worker bundle). We'd need to profile with DevTools against the deployed Worker.

## Test plan

- [x] \`npm run lint\` clean
- [ ] After merge: re-run Lighthouse → 1102 should stop
- [ ] If 1102 persists, investigate Worker bundle size + cold-start behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)