### PR TITLE
fix: unoptimize hero + logo (page wasn't loading; 1102 root cause)

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -53,6 +53,7 @@ export default function Header() {
             height={96}
             className="h-14 sm:h-20 md:h-24 w-auto"
             priority
+            unoptimized
           />
         </Link>
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -35,6 +35,7 @@ export default function HeroSection() {
           alt={`Home exterior in ${season} — Sturrock's HVAC Solutions serves Loudoun, Fairfax, and Frederick counties year-round`}
           fill
           priority
+          unoptimized
           sizes="(max-width: 768px) 100vw, (max-width: 1536px) 100vw, 1920px"
           className="object-cover object-[right_40%_top_75%]"
         />


### PR DESCRIPTION
## The actual root cause

After Ken pulled DevTools open and reported "Provisional headers are shown" on requests, the picture clicked into focus.

The HTML emits an \`imageSrcSet\` preload tag for the hero with **8 size variants** (640/750/828/1080/1200/1920/2048/3840w), plus 2 for the logo. The browser fires all 10 in parallel as preload requests. Each one routes through \`/_next/image\` → Worker → IMAGES binding → optimization. The Worker can't serve 10 parallel optimization invocations on Free tier — they hang indefinitely. Page never finishes loading.

Same root cause as the earlier 1102 errors — the Worker getting overwhelmed by image-optimization requests, just manifesting as a different failure mode (hangs vs. CPU error).

## Fix

Add \`unoptimized\` to the hero and logo Image components. Browser fetches the static asset directly. No Worker invocation. No IMAGES binding work. No hang.

Trade-off: no per-viewport image optimization for these two assets. For the hero (already a 2560×1320 WebP) and the logo (small PNG), this is the right call — the optimization wasn't buying us anything material.

## Test plan

- [x] \`npm run lint\` clean
- [ ] After merge: page loads instantly. \`/_next/image?url=/hero/...\` and \`/_next/image?url=/logo.png\` requests should disappear from network tab; direct \`/hero/spring_hero_2560x1320.webp\` and \`/logo.png\` requests instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)