### PR TITLE
seo: add robots.txt, BreadcrumbList JSON-LD, and Nextdoor sameAs

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+import { brand } from "@/lib/content";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `https://${brand.domain}/sitemap.xml`,
+  };
+}

--- a/app/service-areas/[state]/[county]/[slug]/page.tsx
+++ b/app/service-areas/[state]/[county]/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   regionalLandingPages,
   services,
 } from "@/lib/content";
+import { buildBreadcrumbList } from "@/lib/schema";
 
 // This route handles 3-segment URLs for both tier-1 cities and tier-2
 // regional pages under a county, e.g.:
@@ -259,6 +260,31 @@ function CityPage({
         </section>
 
         <Script
+          id={`breadcrumb-schema-city-${city.slug}`}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              buildBreadcrumbList([
+                { name: "Home", path: "/" },
+                { name: "Service Areas", path: "/service-areas" },
+                {
+                  name: city.state === "VA" ? "Virginia" : "Maryland",
+                  path: `/service-areas/${city.stateSlug}`,
+                },
+                {
+                  name: city.county,
+                  path: `/service-areas/${city.stateSlug}/${city.countySlug}`,
+                },
+                {
+                  name: city.name,
+                  path: `/service-areas/${city.stateSlug}/${city.countySlug}/${city.slug}`,
+                },
+              ]),
+            ),
+          }}
+        />
+
+        <Script
           id={`city-service-schema-${city.slug}`}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
@@ -414,6 +440,31 @@ function RegionalPage({
             </Link>
           </div>
         </section>
+
+        <Script
+          id={`breadcrumb-schema-region-${region.slug}`}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              buildBreadcrumbList([
+                { name: "Home", path: "/" },
+                { name: "Service Areas", path: "/service-areas" },
+                {
+                  name: region.state === "VA" ? "Virginia" : "Maryland",
+                  path: `/service-areas/${region.stateSlug}`,
+                },
+                {
+                  name: region.county,
+                  path: `/service-areas/${region.stateSlug}/${region.countySlug}`,
+                },
+                {
+                  name: region.name,
+                  path: `/service-areas/${region.stateSlug}/${region.countySlug}/${region.slug}`,
+                },
+              ]),
+            ),
+          }}
+        />
 
         <Script
           id={`regional-service-schema-${region.slug}`}

--- a/app/service-areas/[state]/[county]/page.tsx
+++ b/app/service-areas/[state]/[county]/page.tsx
@@ -10,6 +10,7 @@ import {
   regionalLandingPages,
   services,
 } from "@/lib/content";
+import { buildBreadcrumbList } from "@/lib/schema";
 
 // This route handles 2-segment service-area URLs. Two kinds of pages
 // share this URL shape:
@@ -249,6 +250,27 @@ function IndependentCityPage({
         </section>
 
         <Script
+          id={`breadcrumb-schema-independent-city-${city.slug}`}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              buildBreadcrumbList([
+                { name: "Home", path: "/" },
+                { name: "Service Areas", path: "/service-areas" },
+                {
+                  name: city.state === "VA" ? "Virginia" : "Maryland",
+                  path: `/service-areas/${city.stateSlug}`,
+                },
+                {
+                  name: city.name,
+                  path: `/service-areas/${city.stateSlug}/${city.countySlug}`,
+                },
+              ]),
+            ),
+          }}
+        />
+
+        <Script
           id={`independent-city-schema-${city.slug}`}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
@@ -442,6 +464,27 @@ function CountyOverviewPage({
             </Link>
           </div>
         </section>
+
+        <Script
+          id={`breadcrumb-schema-county-${overview.slug}`}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              buildBreadcrumbList([
+                { name: "Home", path: "/" },
+                { name: "Service Areas", path: "/service-areas" },
+                {
+                  name: overview.state === "VA" ? "Virginia" : "Maryland",
+                  path: `/service-areas/${overview.stateSlug}`,
+                },
+                {
+                  name: overview.name,
+                  path: `/service-areas/${overview.stateSlug}/${overview.slug}`,
+                },
+              ]),
+            ),
+          }}
+        />
 
         <Script
           id={`county-overview-schema-${overview.slug}`}

--- a/app/service-areas/[state]/page.tsx
+++ b/app/service-areas/[state]/page.tsx
@@ -9,6 +9,7 @@ import {
   countyOverviews,
   regionalLandingPages,
 } from "@/lib/content";
+import { buildBreadcrumbList } from "@/lib/schema";
 
 // State-level overview page at /service-areas/virginia or /service-areas/maryland.
 
@@ -200,6 +201,20 @@ export default async function StatePage({ params }: Props) {
             </Link>
           </div>
         </section>
+
+        <Script
+          id={`breadcrumb-schema-state-${data.slug}`}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              buildBreadcrumbList([
+                { name: "Home", path: "/" },
+                { name: "Service Areas", path: "/service-areas" },
+                { name: data.name, path: `/service-areas/${data.slug}` },
+              ]),
+            ),
+          }}
+        />
 
         <Script
           id={`state-overview-schema-${data.slug}`}

--- a/app/service-areas/page.tsx
+++ b/app/service-areas/page.tsx
@@ -8,6 +8,7 @@ import {
   countyOverviews,
   regionalLandingPages,
 } from "@/lib/content";
+import { buildBreadcrumbList } from "@/lib/schema";
 
 export const metadata: Metadata = {
   title: "Service Areas",
@@ -184,6 +185,19 @@ export default function ServiceAreasIndex() {
             </Link>
           </div>
         </section>
+
+        <Script
+          id="breadcrumb-schema-service-areas-index"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              buildBreadcrumbList([
+                { name: "Home", path: "/" },
+                { name: "Service Areas", path: "/service-areas" },
+              ]),
+            ),
+          }}
+        />
 
         <Script
           id="service-areas-index-schema"

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -56,7 +56,7 @@ export const companyInfo = {
 
   socialProfiles: {
     yelp: "https://www.yelp.com/biz/sturrocks-hvac-solutions-lovettsville",
-    nextdoor: "",
+    nextdoor: "https://nextdoor.com/pages/sturrocks-hvac-solutions-lovettsville-va/",
     facebook: "",
     google: "",
   },

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,0 +1,20 @@
+import { brand } from "@/lib/content";
+
+export interface BreadcrumbItem {
+  name: string;
+  path: string;
+}
+
+export function buildBreadcrumbList(items: BreadcrumbItem[]) {
+  const baseUrl = `https://${brand.domain}`;
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: `${baseUrl}${item.path}`,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary

Three low-bloat SEO additions to help close the gap on the branded `"sturrocks hvac"` query (currently #4 behind Yelp/Nextdoor/Angi):

- **`app/robots.ts`** — emits `/robots.txt` with a `Sitemap:` pointer. Google finds the sitemap via Search Console, but Bing/DuckDuckGo/etc. rely on robots.txt.
- **BreadcrumbList JSON-LD** on all four service-area page files (six breadcrumb trails total). Google substitutes the breadcrumb path for the raw URL in SERP snippets, which lifts CTR. Factored into a small `lib/schema.ts` helper to avoid duplicating a 12-line structured-data payload six times.
- **`sameAs` Nextdoor URL** in `lib/content.ts` so it flows into the LocalBusiness schema. Strengthens entity-matching for branded queries. Facebook and Google slots remain empty — Andy has no Facebook page, and the Google Maps URL will be added after GBP verification.

## What's *not* in this PR (follow-ups)

- Google Business Profile claim/verification — on Andy (separate email already drafted)
- Google Search Console / Bing Webmaster Tools sitemap submission — off-code, on Ken
- `sameAs` Facebook + Google URLs — blocked on the above

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean — 66 pages + `/robots.txt` + `/sitemap.xml` in route table
- [x] Verified generated `out/robots.txt` contains `Sitemap: https://sturrockshvac.com/sitemap.xml`
- [x] Verified `BreadcrumbList` JSON-LD in `out/service-areas/virginia/loudoun-county/lovettsville.html` — full 5-level trail with canonical URLs on every position
- [ ] (Post-merge) Paste a production URL into Google's Rich Results Test to confirm BreadcrumbList parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)